### PR TITLE
Add NGPU variable to control the number of MPI ranks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ laplace
 *~
 *.nvprof
 *.out
+
+#binaries
+laplace2d

--- a/labs/lab4.Multi_GPU_Programming_with_MPI_and_OpenACC/C/task2/Makefile
+++ b/labs/lab4.Multi_GPU_Programming_with_MPI_and_OpenACC/C/task2/Makefile
@@ -1,5 +1,7 @@
 all: run
 
+NGPUS?=2
+
 laplace2d: laplace2d.c common.h laplace2d_serial.h Makefile
 	mpicc -fast -acc -ta=tesla:cc35 -ta=tesla:cc50 laplace2d.c -o laplace2d
 
@@ -7,14 +9,14 @@ clean:
 	rm -f laplace2d laplace2d.solution laplace2d.*.nvvp
 
 run: laplace2d
-	mpirun -np 4 ./laplace2d
+	mpirun -np ${NGPUS} ./laplace2d
 
 profile: laplace2d
-	mpirun -np 4 nvprof -o laplace2d.%q{OMPI_COMM_WORLD_RANK}.nvvp ./laplace2d
+	mpirun -np ${NGPUS} nvprof -o laplace2d.%q{OMPI_COMM_WORLD_RANK}.nvvp ./laplace2d
 
 laplace2d.solution: laplace2d.solution.c common.h laplace2d_serial.h Makefile
 	mpicc -fast -acc -ta=tesla:cc35 -ta=tesla:cc50 laplace2d.solution.c -o laplace2d.solution
 
 solution: laplace2d.solution
-	mpirun -np 4 ./laplace2d.solution
+	mpirun -np ${NGPUS} ./laplace2d.solution
 

--- a/labs/lab4.Multi_GPU_Programming_with_MPI_and_OpenACC/C/task3/Makefile
+++ b/labs/lab4.Multi_GPU_Programming_with_MPI_and_OpenACC/C/task3/Makefile
@@ -1,5 +1,7 @@
 all: run
 
+NGPUS?=4
+
 laplace2d: laplace2d.c common.h laplace2d_serial.h Makefile
 	mpicc -fast -acc -ta=tesla:cc35 -ta=tesla:cc50 laplace2d.c -o laplace2d
 
@@ -7,14 +9,14 @@ clean:
 	rm -f laplace2d laplace2d.solution laplace2d.*.nvvp
 
 run: laplace2d
-	mpirun -np 4 ./laplace2d 
+	mpirun -np ${NGPUS} ./laplace2d 
 
 profile: laplace2d
-	mpirun -np 4 nvprof -o laplace2d.%q{OMPI_COMM_WORLD_RANK}.nvvp ./laplace2d
+	mpirun -np ${NGPUS} nvprof -o laplace2d.%q{OMPI_COMM_WORLD_RANK}.nvvp ./laplace2d
 
 laplace2d.solution: laplace2d.solution.c common.h laplace2d_serial.h Makefile
 	mpicc -fast -acc -ta=tesla:cc35 -ta=tesla:cc50 laplace2d.solution.c -o laplace2d.solution
 
 solution: laplace2d.solution
-	mpirun -np 4 ./laplace2d.solution
+	mpirun -np ${NGPUS} ./laplace2d.solution
 

--- a/labs/lab4.Multi_GPU_Programming_with_MPI_and_OpenACC/FORTRAN/task2/Makefile
+++ b/labs/lab4.Multi_GPU_Programming_with_MPI_and_OpenACC/FORTRAN/task2/Makefile
@@ -1,5 +1,7 @@
 all: run
 
+NGPUS?=4
+
 laplace2d: laplace2d.F03 laplace2d_serial.F03 Makefile
 	mpifort -fast -acc -ta=tesla:cc35 -ta=tesla:cc50 -Minfo=accel laplace2d.F03 laplace2d_serial.F03 -o laplace2d
 
@@ -7,14 +9,14 @@ clean:
 	rm -f laplace2d laplace2d.solution *.o
 
 run: laplace2d
-	mpirun -np 4 ./laplace2d
+	mpirun -np ${NGPUS} ./laplace2d
 
 profile: laplace2d
-	mpirun -np 4 nvprof -o laplace2d.%q{OMPI_COMM_WORLD_RANK}.nvvp ./laplace2d
+	mpirun -np ${NGPUS} nvprof -o laplace2d.%q{OMPI_COMM_WORLD_RANK}.nvvp ./laplace2d
 
 laplace2d.solution: laplace2d.solution.F03 laplace2d_serial.F03 Makefile
 	mpifort -fast -acc -ta=tesla:cc35 -ta=tesla:cc50 -Minfo=accel laplace2d.solution.F03 laplace2d_serial.F03 -o laplace2d.solution
 
 solution: laplace2d.solution
-	mpirun -np 4 ./laplace2d.solution
+	mpirun -np ${NGPUS} ./laplace2d.solution
 

--- a/labs/lab4.Multi_GPU_Programming_with_MPI_and_OpenACC/FORTRAN/task3/Makefile
+++ b/labs/lab4.Multi_GPU_Programming_with_MPI_and_OpenACC/FORTRAN/task3/Makefile
@@ -1,5 +1,7 @@
 all: run
 
+NGPUS?=4
+
 laplace2d: laplace2d.F03 laplace2d_serial.F03 Makefile
 	mpifort -fast -acc -ta=tesla:cc35 -ta=tesla:cc50 -Minfo=accel laplace2d.F03 laplace2d_serial.F03 -o laplace2d
 
@@ -7,14 +9,14 @@ clean:
 	rm -f laplace2d laplace2d.solution *.o
 
 run: laplace2d
-	mpirun -np 4 ./laplace2d
+	mpirun -np ${NGPUS} ./laplace2d
 
 profile: laplace2d
-	mpirun -np 4 nvprof -o laplace2d.%q{OMPI_COMM_WORLD_RANK}.nvvp ./laplace2d
+	mpirun -np ${NGPUS} nvprof -o laplace2d.%q{OMPI_COMM_WORLD_RANK}.nvvp ./laplace2d
 
 laplace2d.solution: laplace2d.solution.F03 laplace2d_serial.F03 Makefile
 	mpifort -fast -acc -ta=tesla:cc35 -ta=tesla:cc50 -Minfo=accel laplace2d.solution.F03 laplace2d_serial.F03 -o laplace2d.solution
 
 solution: laplace2d.solution
-	mpirun -np 4 ./laplace2d.solution
+	mpirun -np ${NGPUS} ./laplace2d.solution
 


### PR DESCRIPTION
Add NGPU variable to control the number of MPI ranks.
This is useful for machines with only 2 GPUs/node (default was 4 GPUs/node).

Now in

>  lab4.Multi_GPU_Programming_with_MPI_and_OpenACC

`make` will use 4 GPUs
`NGPUS=2 make` will use 2 GPUs
